### PR TITLE
Clarified instructions for using `git cherry-pick`

### DIFF
--- a/lab_instructions_part1.md
+++ b/lab_instructions_part1.md
@@ -171,6 +171,7 @@ While we used **Git Merge (`--no-ff`)**, be aware of these alternatives:
 **All Members** should practice viewing the "technical lab notes" of the project to ensure the process is transparent.
 
 * Go back to the main branch: `git checkout main`
+* Confirm that the remote branch is up to date with the branch in the origin by running `git status`
 * Then run `git log --oneline --graph` to view the repository history. You should see a series of "knots" representing the deliberate merge commits made by each team member.
 
 * **View a Graph of Merges:** To see how branches have evolved and joined, run:

--- a/lab_instructions_part2.md
+++ b/lab_instructions_part2.md
@@ -1,23 +1,32 @@
 # Part 2: Advanced Git Commands for Team Collaboration
 
 * Go back to the feature branch: `git checkout feature/issue-number-description`
+* Confirm that the remote branch is up to date with the branch in the origin by running `git status`
+
+---
 
 ## 11. Moving Work Around (`git cherry-pick`)
 
 **Member 2** will simulate a common mistake: committing work to the **wrong branch**.
 
-1. **The Mistake:** Imagine you accidentally committed a "Data Cleaning" update to your `feature/issue-number-description` branch, but it actually belonged in a separate "Refactoring" branch.
-2. **Get the ID:** Find the **Commit ID (SHA value)** of the misplaced commit using `git log --oneline`.
+1. **The Mistake:** Imagine you accidentally committed an update directly in the `main` branch instead of through a `feature` branch.
+2. **Get the ID:** Find the **Commit ID (SHA value)** of the misplaced commit in the `main` branch.
+    * You need to be in the branch that contains the misplaced commit first: `git checkout main`
+    * Then view the commit IDs (SHA values) using `git log --oneline`.
 3. **Switch and Copy:**
 
+    * Switch back to the correct feature branch first then perform the cherry-pick:
+
     ```bash
-    git checkout -b feature/data-refactoring
+    git checkout feature/issue-number-description
     git cherry-pick <Commit-ID-from-Step-2>
     ```
 
-    *Note: Git applies those changes to your current branch and creates a **new commit ID**, while the original commit remains on the old branch.*
+    *Note: Git applies those changes to your current branch and creates a **new commit ID**, while the original commit remains in the old branch.*
 
-4. **Clean up:** Switch back to the original branch and use `git reset` (see Section 9) to remove the duplicate commit from the wrong location.
+4. **Clean up:** Switch back to the branch that had the misplaced commit and use `git reset` (see Section 9) to remove the duplicate commit from the wrong location.
+
+---
 
 ## 9. Reversing Changes (`git revert` vs. `git reset`)
 


### PR DESCRIPTION
- Used to move commits between branches, including the need to switch to the correct branch before performing the cherry picking and the fact that it creates a new commit ID.
- Also added a reminder to clean up the original branch after cherry-picking.